### PR TITLE
Tests now pass on MsWin32 platforms

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,8 @@
 Revision history for System-Sub.
 
 {{$NEXT}}
-
+	Updated tests to allow tests to pass on MsWin32 platform
+	
 0.130270     2013-01-27    DOLMEN (Olivier Mengué)
 	Added 'Changes' file.
 	Added tests created by BOOK. Thanks!

--- a/t/git.t
+++ b/t/git.t
@@ -40,14 +40,14 @@ plan skip_all => 'Could not get a meaningful result from git::version'
 diag "Testing <$git_version>";
 
 # init a repository
-ok( !-d "$dir/.git", 'no repository yet' );
+ok( !-d "$dir/.git", 'Verify no repository yet' );
 git::init;
-ok( -d "$dir/.git", 'init' );
+ok( -d "$dir/.git", '[init] Initialize repositry ' );
 $tested{init}++;
 
 # create the emptry tree
 my $tree = git::mktree( \'' );
-is( $tree, '4b825dc642cb6eb9a060e54bf8d69288fbee4904', 'mktree' );
+is( $tree, '4b825dc642cb6eb9a060e54bf8d69288fbee4904', '[mktree] Creating empty tree' );
 $tested{mktree}++;
 
 # commit it
@@ -55,7 +55,7 @@ $ENV{GIT_AUTHOR_DATE}    = 'Mon Jan 21 21:14:18 CET 2013';
 $ENV{GIT_COMMITTER_DATE} = 'Mon Jan 21 21:14:18 CET 2013';
 my $commit = git::commit_tree $tree, \'empty tree';
 $tested{commit_tree}++;
-is( $commit, '52870678501379ecd14277fad5e69961ce7bd39b', 'commit_tree' );
+is( $commit, '52870678501379ecd14277fad5e69961ce7bd39b', '[commit_tree] Committing empty tree' );
 
 # point master to it
 git::update_ref 'refs/heads/master', $commit;
@@ -63,16 +63,16 @@ $tested{update_ref}++;
 
 # check we got it right
 my $log = git::log qw( --pretty=format:%H -1 );
-is( $log, $commit, 'log' );
+is( $log, $commit, '[log] Verify commit tree' );
 
 $log = git::log qw( --pretty=format:%s -1 );
-is( $log, 'empty tree', 'log' );
+is( $log, 'empty tree', '[log] Verify empty tree' );
 
 # create a new branch
 git::checkout -b => 'branch';
 $tested{checkout}++;
 
-is_deeply( [git::branch], [ '* branch', '  master' ], 'branch' );
+is_deeply( [git::branch], [ '* branch', '  master' ], '[branch] Verify branch' );
 $tested{branch}++;
 
 # add a new file
@@ -81,12 +81,12 @@ print $fh "Hello, world!\n";
 close $fh;
 
 is_deeply( [ git::status '--porcelain' ],
-    ['?? hello.txt'], 'status --porcelain' );
+    ['?? hello.txt'], '[status --porcelain] Status with missing file' );
 $tested{status}++;
 git::add 'hello.txt';
 $tested{add}++;
 is_deeply( [ git::status '--porcelain' ],
-    ['A  hello.txt'], 'status --porcelain' );
+    ['A  hello.txt'], '[status --porcelain] Status with added file' );
 $tested{status}++;
 
 # and commit it
@@ -96,7 +96,7 @@ git::commit -m => 'hello';
 $tested{commit}++;
 $commit = git::log qw( -1 --pretty=format:%H );
 $tested{log}++;
-is( $commit, 'b462686c994180efe7fcf5e4e682907834c93f38', 'log' );
+is( $commit, 'b462686c994180efe7fcf5e4e682907834c93f38', '[log] Verify commit' );
 
 # check an unsupported command
 use Git::Sub 'show_branch';

--- a/t/git.t
+++ b/t/git.t
@@ -106,7 +106,7 @@ is( $commit, 'b462686c994180efe7fcf5e4e682907834c93f38', '[log] Verify commit' )
 use Git::Sub 'show_branch';
 is_deeply(
     [ git::show_branch '--all' ],
-    [ split /\n/, << 'EOT' ], 'show-branch' );
+    [ split /\n/, << 'EOT' ], qq{[show-branch] Verify output of show_branch} );
 * [branch] hello
  ! [master] empty tree
 --
@@ -116,7 +116,7 @@ EOT
 
 is_deeply(
     [ git::cat_file commit => $commit ],
-    [ split /\n/, << 'EOT' ], 'cat_file' );
+    [ split /\n/, << 'EOT' ], qq{[cat-file] Verify output of cat_file} );
 tree ec947e3dd7a7752d078f1ed0cfde7457b21fef58
 parent 52870678501379ecd14277fad5e69961ce7bd39b
 author Test Author <test.author@example.com> 1358799259 +0100
@@ -126,10 +126,10 @@ hello
 EOT
 $tested{cat_file}++;
 
-is_deeply( [ git::ls_tree 'master' ], [], 'ls_tree' );
+is_deeply( [ git::ls_tree 'master' ], [], qq{[ls_tree] Verify ls of "master"} );
 is_deeply( [ git::ls_tree 'branch' ],
     ["100644 blob af5626b4a114abcb82d63db7c8082c3c4756e51b\thello.txt"],
-    'ls_tree' );
+    qq{[ls_tree] Verify ls of "branch"} );
 
 # inform us about untested commands
 diag "Not tested: ", join ' ', sort grep !exists $tested{$_},

--- a/t/git.t
+++ b/t/git.t
@@ -11,8 +11,16 @@ $ENV{GIT_AUTHOR_NAME}     = 'Test Author';
 $ENV{GIT_AUTHOR_EMAIL}    = 'test.author@example.com';
 $ENV{GIT_COMMITTER_NAME}  = 'Test Committer';
 $ENV{GIT_COMMITTER_EMAIL} = 'test.committer@example.com';
+my $keep_tempdir = ($ENV{SKIP_TEMPDIR_CLEANUP} ? 1 : 0);
 my $home = cwd;
-my $dir = tempdir( CLEANUP => 1 );
+my $dir = tempdir( qq{git-sub-XXXXXXXX}, TMPDIR => 1, CLEANUP => ($keep_tempdir ? 0 : 1));
+
+diag qq{\nTest directory created "$dir"\n};
+if ($keep_tempdir) {
+  diag qq{SKIP_TEMPDIR_CLEANUP is TRUE, keeping the temporary directory\n};
+} else {
+  diag qq{SKIP_TEMPDIR_CLEANUP not defined or FALSE, deleting the temporary directory\n};
+}
 
 # need to be there to test
 chdir $dir;

--- a/t/git.t
+++ b/t/git.t
@@ -111,7 +111,7 @@ is_deeply(
 EOT
 
 is_deeply(
-    [ git::cat_file commit => 'b462686c994180efe7fcf5e4e682907834c93f38' ],
+    [ git::cat_file commit => $commit ],
     [ split /\n/, << 'EOT' ], 'cat_file' );
 tree ec947e3dd7a7752d078f1ed0cfde7457b21fef58
 parent 52870678501379ecd14277fad5e69961ce7bd39b

--- a/t/git.t
+++ b/t/git.t
@@ -77,6 +77,10 @@ $tested{branch}++;
 
 # add a new file
 open my $fh, '>', 'hello.txt';
+# In order to avoid translating \n to \r\n on MsWin text files, use binmode()
+# If binmode is not used, the hash created for the commit of the text file
+# will be different and cause subsequent tests to fail
+binmode $fh;
 print $fh "Hello, world!\n";
 close $fh;
 


### PR DESCRIPTION
* Updated git.t to use binmode() to avoid newline translation to/from LF to CRLF. This allows the tests to pass on the MsWin32 platform
* Verified tests pass on:
  - Windows 7, 64-bit [(v5.20.1) built for MSWin32-x86-multi-thread-64int]
  - Ubuntu 14.04 LTS [(v5.18.2) built for x86_64-gnu-thread-multi]
* Added more descriptions to the test names